### PR TITLE
GH URL option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ To use this plugin, add an ``edgetest.hub`` section to your configuration:
 
 ```ini
 [edgetest.hub]
+git_url = github.com  # optional
 git_repo_org = org-name
 git_repo_name = repo-name
 git_username = Jenkins  # optional

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,7 +25,7 @@ copyright = "2021, Capital One"
 author = "Faisal Dosani"
 
 # The short X.Y version
-version = "2021.12.3"
+version = "2022.2.0"
 # The full version, including alpha/beta/rc tags
 release = ""
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -29,6 +29,7 @@ to your configuration:
 .. code-block:: ini
 
     [edgetest.hub]
+    git_url = github.com  # optional
     git_repo_org = org-name
     git_repo_name = repo-name
     git_username = Jenkins  # optional

--- a/edgetest_hub/__init__.py
+++ b/edgetest_hub/__init__.py
@@ -1,6 +1,6 @@
 """Package initialization."""
 
-__version__ = "2021.12.3"
+__version__ = "2022.2.0"
 
 __title__ = "edgetest-hub"
 __description__ = "Edgetest hub plugin"

--- a/edgetest_hub/plugin.py
+++ b/edgetest_hub/plugin.py
@@ -29,7 +29,7 @@ def configure_branch(conf: Dict):
     None
     """
     git_repo_url = (
-        f"https://{os.environ[GIT_TOKEN_ENVNAME]}@github.com/"
+        f"https://{os.environ[GIT_TOKEN_ENVNAME]}@{conf['hub']['git_url']}/"
         f"{conf['hub']['git_repo_org']}/{conf['hub']['git_repo_name']}.git"
     )
     out, _ = _run_command(
@@ -46,7 +46,7 @@ def configure_branch(conf: Dict):
         "--global",
         "--add",
         "hub.host",
-        "github.com",
+        conf["hub"]["git_url"],
     )
 
     try:  # delete any remote updater_branch
@@ -155,6 +155,11 @@ def addoption(schema: Schema):
         {
             "type": "dict",
             "schema": {
+                "git_url": {
+                    "type": "string",
+                    "coerce": "strip",
+                    "default": "github.com",
+                },
                 "git_repo_org": {
                     "type": "string",
                     "coerce": "strip",

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,7 +81,7 @@ edgetest =
 	hub = edgetest_hub.plugin
 
 [bumpver]
-current_version = "2021.12.3"
+current_version = "2022.2.0"
 version_pattern = "YYYY.MM.INC0"
 commit_message = "Bump {old_version} to {new_version}"
 commit = True


### PR DESCRIPTION
This should fix #7 :

- Adds an option to configuring the GitHub URL (useful for enterprise GitHub installations)
- defaults to `github.com`
